### PR TITLE
closes #79

### DIFF
--- a/client/assets/styles/index.css
+++ b/client/assets/styles/index.css
@@ -216,3 +216,15 @@ body .login_fields__submit input:hover {
 .quantity: {
   margin: 3px 0px 15px 0px;
 }
+
+.login {
+  box-sizing: content-box;
+}
+
+.login-fields {
+  box-sizing: content-box;
+}
+
+.login-title {
+  box-sizing: content-box;
+}


### PR DESCRIPTION
stop login box from inheriting sizing issues from bootstrap by overriding in own styles
